### PR TITLE
Create Disk Partition and Format Filesystem

### DIFF
--- a/config/ostree-local.yaml
+++ b/config/ostree-local.yaml
@@ -6,7 +6,7 @@ disk:
   device: /dev/vda
   partitions:
     - name: EFI
-      start: O%
+      start: 0%
       end: 256MB
       flags: [boot, esp]
     - name: ROOT

--- a/tiler/image.py
+++ b/tiler/image.py
@@ -1,0 +1,88 @@
+
+import logging
+import os
+import shlex
+import subprocess
+
+from tiler import utils
+
+
+class ImagePart(object):
+    def __init__(self, state, config):
+        self.state = state
+        self.config = config
+
+        self.logging = logging.getLogger(__name__)
+        self.disk = self.config.get("disk")
+        self.device = self.disk.get("device")
+        self.partitiontype = self.disk.get("partitiontype")
+
+        self.partitions = self.disk.get("partitions")
+        self.filesystems = self.disk.get("filesystems")
+
+    def run(self):
+        self.create_label()
+        self.create_partitions()
+        self.create_filesystems()
+
+    def create_label(self):
+        label = self.disk.get("label") or "gpt"
+        if os.path.exists(self.device):
+            utils.run_command(
+                ["parted", self.device, "--script", "mklabel", label])
+
+    def create_partitions(self):
+        """Use parted to create the partitions."""
+        for index, part in enumerate(self.partitions, start=1):
+            (err, out) = utils.run_command(
+                ["parted", "-s", self.device, "--", "mkpart", part.get("name"),
+                 part.get("start"), part.get("end")])
+            flags = part.get("flags")
+            if flags:
+                for flag in flags:
+                    cmd = f"parted -s {self.device} -- set {index} {flag} on"
+                    utils.run_command(shlex.split(cmd))
+            part_type = part.get("type")
+            if part_type:
+                cmd = f"sfdisk --part-type {self.device} {index} {part_type}"
+                utils.run_command(shlex.split(cmd))
+
+    def create_filesystems(self):
+        """Setup the disk for the filesystems to be formatted."""
+        for index, part in enumerate(self.filesystems, start=1):
+            fs = self.get_partition_device(index, self.device)
+            if os.path.exists(fs):
+                self.mkfs(fs,
+                          part.get("fs"),
+                          part.get("label"),
+                          part.get("name"))
+
+
+    def mkfs(self, fs, fs_type, label, name):
+        """Formatting the filesystem."""
+        self.logging.info(f"Formatting filesystems for {name}.")
+
+        if fs_type == "vfat":
+            # vfat is a special case
+            subprocess.run(
+                ["mkfs.vfat", "-F", "32", "-n", label, fs],
+                check=True)
+        else:
+            subprocess.run(
+                ["mkfs", "-F", "-t", fs_type, "-L", label, fs], check=True)
+
+
+    def get_partition_device(self, number, device):
+        suffic = "p"
+        # Check partition naming first: if used 'by-id'i naming convention
+        if "/disk/by-id" in device:
+            suffix = "-part"
+
+        # If the iamge device has a digit as the last character, the partition
+        # suffix is p<number> else it's just <number>
+        last = device[len(device)-1]
+        if last >= "0" and last <= "9":
+            return "%s%s%d" % (device, suffix, number)
+        else:
+            return "%s%d" % (device, number)
+

--- a/tiler/install.py
+++ b/tiler/install.py
@@ -8,6 +8,7 @@ import logging
 
 from tiler.config import Config
 from tiler.config import exceptions
+from tiler.image import ImagePart
 
 LOG = logging.getLogger(__name__)
 
@@ -16,6 +17,7 @@ class Installer(object):
     def __init__(self, state):
         self.state = state
         self.config = Config(self.state)
+        self.image = None
 
     def install(self):
         LOG.info("Installing Debian Linux.")
@@ -26,5 +28,9 @@ class Installer(object):
                 f"Failed to load configuration: {self.state.config}")
         config = self.config.load_config()
 
-        LOG.info("Perforfind install")
         print(config)
+
+        LOG.info("Create Disk Partition and Format Filesystem")
+        self.image = ImagePart(self.state, config).run()
+
+        LOG.info("Perforfind install")


### PR DESCRIPTION
$ sudo tiler --debug install --config config/ostree-local.yaml 2024-03-19 09:56:33,517 Loading tiler.
2024-03-19 09:56:33,521 Installing Debian Linux.
2024-03-19 09:56:33,522 Loading configuration file. {'source': {'repository': '/var/www/html/repo', 'branch': 'pablo/1.0'}, 'disk': {'device': '/dev/vda', 'partitions': [{'name': 'EFI', 'start': '0%', 'end': '256MB', 'flags': ['boot', 'esp']}, {'name': 'ROOT', 'start': '256MB', 'end': '100%'}], 'filesystems': [{'name': 'EFI', 'label': 'EFI', 'fs': 'vfat', 'options': []}, {'name': 'ROOT', 'label': 'ROOT', 'fs': 'ext4', 'options': []}]}} 2024-03-19 09:56:33,526 Create Disk Partition and Format Filesystem 2024-03-19 09:56:33,527 Running ['parted', '/dev/vda', '--script', 'mklabel', 'gpt'] 2024-03-19 09:56:33,613 rc 0
2024-03-19 09:56:33,614 Running ['parted', '-s', '/dev/vda', '--', 'mkpart', 'EFI', '0%', '256MB'] 2024-03-19 09:56:33,696 rc 0
2024-03-19 09:56:33,701 Running ['parted', '-s', '/dev/vda', '--', 'set', '1', 'boot', 'on'] 2024-03-19 09:56:33,778 rc 0
2024-03-19 09:56:33,780 Running ['parted', '-s', '/dev/vda', '--', 'set', '1', 'esp', 'on'] 2024-03-19 09:56:33,860 rc 0
2024-03-19 09:56:33,867 Running ['parted', '-s', '/dev/vda', '--', 'mkpart', 'ROOT', '256MB', '100%'] 2024-03-19 09:56:33,953 rc 0
2024-03-19 09:56:33,954 Formatting filesystems for EFI. mkfs.fat 4.2 (2021-01-31)
2024-03-19 09:56:34,028 Formatting filesystems for ROOT. mke2fs 1.47.0 (5-Feb-2023)
/dev/vda2 contains a ext4 file system labelled 'ROOT'
        created on Tue Mar 19 09:55:13 2024
Discarding device blocks: done
Creating filesystem with 134155008 4k blocks and 33546240 inodes Filesystem UUID: 328830c8-aba3-4e1f-ac9f-20e58dfa4284 Superblock backups stored on blocks:
        32768, 98304, 163840, 229376, 294912, 819200, 884736, 1605632, 2654208,
        4096000, 7962624, 11239424, 20480000, 23887872, 71663616, 78675968,
        102400000

Allocating group tables: done
Writing inode tables: done
Creating journal (262144 blocks): done
Writing superblocks and filesystem accounting information: done

2024-03-19 09:56:34,136 Perforfind install

$ sudo blkid /dev/vda*
/dev/vda: PTUUID="204d1d60-03d7-4356-9d9c-dbf685c01df5" PTTYPE="gpt" /dev/vda1: LABEL_FATBOOT="EFI" LABEL="EFI" UUID="991E-982F" BLOCK_SIZE="512" TYPE="vfat" PARTLABEL="EFI" PARTUUID="216dca23-4699-43ba-98b4-15595de1f2e6" /dev/vda2: LABEL="ROOT" UUID="328830c8-aba3-4e1f-ac9f-20e58dfa4284" BLOCK_SIZE="4096" TYPE="ext4" PARTLABEL="ROOT" PARTUUID="42772224-763b-4ce1-aa53-9158a744e593"

$ sudo fdisk -l /dev/vda
Disk /dev/vda: 512 GiB, 549755813888 bytes, 1073741824 sectors Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes I/O size (minimum/optimal): 512 bytes / 512 bytes
Disklabel type: gpt
Disk identifier: 204D1D60-03D7-4356-9D9C-DBF685C01DF5

Device      Start        End    Sectors   Size Type
/dev/vda1    2048     499711     497664   243M EFI System
/dev/vda2  499712 1073739775 1073240064 511.8G Linux filesystem