### PR TITLE
support to install from remote ostree repository

### DIFF
--- a/config/disk/ostree-remote.yaml
+++ b/config/disk/ostree-remote.yaml
@@ -1,6 +1,6 @@
 ---
 source:
-  host: http://192.168.100.106/repo
+  repository: http://127.0.0.1/repo
   branch: exampleos/testing
   kernel_args:
     - root=LABEL=ROOT
@@ -11,7 +11,7 @@ disk:
   device: /dev/vda
   partitions:
     - name: EFI
-      start: O%
+      start: 0%
       end: 256MB
       flags: [boot, esp]
     - name: ROOT

--- a/tiler/ostree.py
+++ b/tiler/ostree.py
@@ -47,9 +47,19 @@ class OstreeDeploy(object):
         ostree_repo.mkdir(parents=True, exist_ok=True)
         utils.run_command(
             ["ostree", "init", "--repo", ostree_repo, "--mode", "bare"])
-        self.logging.info(f"Pulling {branch}")
-        utils.run_command(
-            ["ostree", "pull-local", "--repo", ostree_repo, repo, branch])
+        self.logging.info(f"Pulling {branch} from {repo}")
+        if repo.startswith("http"):
+            utils.run_command(
+                ["ostree", "remote", "--repo={0}".format(ostree_repo), "add", "--no-gpg-verify", "pablo-edge", repo])
+            utils.run_command(
+                ["ostree", "pull", "--repo={0}".format(ostree_repo), "pablo-edge", branch])
+        elif os.path.exists(repo):
+            utils.run_command(
+                ["ostree", "pull-local", "--repo", ostree_repo, repo, branch])
+        else:
+            self.logging.error("Invalid ostree repository {repo}")
+            sys.exit(1)
+
         utils.run_command(
             ["ostree", "config", "--repo", ostree_repo, "--group", "sysroot",
              "set", "bootloader", "none"])


### PR DESCRIPTION
Test steps:
1. Create ostree repository $ cd config/uefi-ostree
$ sudo ruck build --config image.yaml

2. Start Web Server $ sudo apt install apache2

3. Install from remote ostree repository $ sudo tiler install --config config/disk/ostree-remote.yaml ...
2024-03-27 07:11:59,387 Pulling exampleos/testing from http://127.0.0.1/repo 3686 metadata, 30238 content objects fetched; 467174 KiB transferred in 36 seconds; 1.3 GB content written ...

4. Install from local ostree repository $ sudo tiler install --config config/disk/ostree-local.yaml ...
2024-03-27 07:15:05,620 Pulling exampleos/testing from /var/www/html/repo 3684 metadata, 30238 content objects imported; 1.3 GB content written ...