### PR TITLE
assemble arm64 image in amd64 container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,7 @@ FROM debian:bookworm
 
 RUN apt-get update && \
     apt-get install -y \
+        arch-test \
         mmdebstrap \
         python3-pip \
         python3-yaml \
@@ -22,8 +23,6 @@ RUN apt-get update && \
         qemu-utils \
         gir1.2-ostree-1.0 \
         git
-
-RUN if [ "$(uname -m)" = "x86_64" ]; then apt update && apt install qemu-user-static arch-test -y; fi
 
 COPY files/pip.conf /etc/pip.conf
 

--- a/tools/build-container.sh
+++ b/tools/build-container.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
+# qemu-binfmt with non-native chroot
+sudo apt update
+sudo apt install qemu-user-static -y
 docker build -t tiler docker


### PR DESCRIPTION
1. In order to support qemu-binfmt with non-native chroot, install qemu-user-static on host rather than in container

On debian 12 host, after insatll qemu-user-static

$ cat /proc/sys/fs/binfmt_misc/qemu-aarch64
enabled
interpreter /usr/libexec/qemu-binfmt/aarch64-binfmt-P flags: POCF
offset 0
magic 7f454c460201010000000000000000000200b700
mask ffffffffffffff00fffffffffffffffffeffffff

On an amd64 host:
$ debootstrap --arch=arm64 buster buster-chroot http://deb.debian.org/debian ...
$ chroot buster-chroot /bin/bash

See https://issues.guix.gnu.org/36117 for detail

2. Install arch-test in container unconditionally which is required by mmdebstrap

root@0fb7bae77452:/usr/src/config/ostree-arm64/# ruck build --config image.yaml ...
2024-04-01 12:30:49,605 Running mmdebstrap.
I: automatically chosen mode: root
E: install arch-test for foreign architecture support