### PR TITLE
assemble arm64 image in amd64 container

### DIFF
--- a/doc/source/developer.txt
+++ b/doc/source/developer.txt
@@ -42,7 +42,7 @@ repository run the following commands:
 
     qemu-img create -f raw ./pablo-image.img 32G
 
-    losetup /dev/loop1 ./pablo-image.img
+    losetup --partscan /dev/loop1 ./pablo-image.img
 
 3. Run tiler to install from local ostree repository
 

--- a/doc/source/developer.txt
+++ b/doc/source/developer.txt
@@ -2,11 +2,18 @@
 
 To create a dev environment for tiler
 
-1. Build the dev container from the main directory, run:
+In order to use ruck and tiler in a container you be using docker. The host
+should be running a Debian based Linux distrobution.
+
+1. If assemble arm64 image in amd64 container, install qemu-user-static
+
+    sudo apt install qemu-user-static -y
+
+2. Build the dev container from the main directory, run:
 
     tools/build-container.sh
 
-2. To run the dev container from the main directory, run:
+3. To run the dev container from the main directory, run:
 
     tools/run-dev.sh
 

--- a/tiler/machine.py
+++ b/tiler/machine.py
@@ -1,0 +1,29 @@
+"""
+Copyright (c) 2024 Wind River Systems, Inc.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+import os
+import stat
+from platform import machine
+
+import logging
+
+LOG = logging.getLogger(__name__)
+
+arch2machine = {
+  "amd64":"x86_64",
+  "arm64":"aarch64",
+}
+
+def valid_arch(arch):
+    """Check to see if arch is a valid or not."""
+    if not arch2machine.get(arch):
+        LOG.error("Unkown arch %s" % arch)
+        return False
+
+    if arch2machine.get(arch) != machine():
+        LOG.error("Arch %s(%s) is not supported on %s", arch, arch2machine.get(arch), machine())
+        return False
+
+    return True

--- a/tiler/modules/installer/ostree.py
+++ b/tiler/modules/installer/ostree.py
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import logging
+import sys
 
 from tiler.modules.base import ModuleBase
 from tiler.mount import mount
@@ -28,7 +29,10 @@ class OstreeInit(ModuleBase):
         self.logging.info("Unpacking source.")
 
         self.logging.info(f"Mounting {self.device} on {self.rootfs}.")
-        mount(self.device, self.rootfs)
+        ret = mount(self.device, self.rootfs)
+        if ret != 0:
+            self.logging.error(f"Mounted {self.device} on {self.rootfs} failed.")
+            sys.exit(1)
 
         repo = self.rootfs.joinpath("ostree/repo")
         self.logging.info(f"Creating {repo}")

--- a/tiler/modules/installer/unpack.py
+++ b/tiler/modules/installer/unpack.py
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import logging
 import os
+import sys
 
 from tiler.modules.base import ModuleBase
 from tiler.mount import mount
@@ -36,7 +37,10 @@ class Unpack(ModuleBase):
             self.rootfs.mkdir(parents=True, exist_ok=True)
 
         self.logging.info(f"Mounting {self.device} on {self.rootfs}.")
-        mount(self.device, self.rootfs)
+        ret = mount(self.device, self.rootfs)
+        if ret != 0:
+            self.logging.error(f"Mounted {self.device} on {self.rootfs} failed.")
+            sys.exit(1)
 
         self.logging.info(f"Unpacking {self.source}.")
         utils.run_command(

--- a/tiler/modules/stages/early.py
+++ b/tiler/modules/stages/early.py
@@ -9,6 +9,8 @@ import logging
 from stevedore import driver
 
 from tiler.block import is_block
+from tiler.machine import valid_arch
+
 from tiler.modules.base import ModuleBase
 
 
@@ -28,6 +30,11 @@ class Early(ModuleBase):
         if not is_block(self.config.params.disk):
             raise Exception(
                 f"{self.config.params.disk} is not a block device.")
+
+        self.logging.info("Checking for architecture.")
+        if not valid_arch(self.config.architecture):
+            raise Exception(
+                f"Invalid architecture: {self.config.architecture}.")
 
         if self.config.stages.early:
             for step in self.config.stages.early:

--- a/tiler/modules/stages/post.py
+++ b/tiler/modules/stages/post.py
@@ -42,4 +42,7 @@ class Post(ModuleBase):
                     )
         if os.path.ismount(self.rootfs):
             self.logging.info("Cleaning up")
-            umount(self.rootfs)
+            ret = umount(self.rootfs)
+            if ret != 0:
+                self.logging.error(f"Umounted {self.rootfs} failed.")
+                sys.exit(1)

--- a/tiler/mount.py
+++ b/tiler/mount.py
@@ -9,10 +9,11 @@ from tiler import utils
 
 
 def mount(image, rootfs):
-    utils.run_command(
+    ret,_,_ = utils.run_command(
         ["systemd-dissect", "-m", image, rootfs])
-
+    return ret
 
 def umount(rootfs):
-    utils.run_command(
+    ret,_,_ = utils.run_command(
         ["systemd-dissect", "-u", rootfs])
+    return ret


### PR DESCRIPTION
1. In order to support qemu-binfmt with non-native chroot, install qemu-user-static on host rather than in container

On debian 12 host, install qemu-user-static

$ cat /proc/sys/fs/binfmt_misc/qemu-aarch64
enabled
interpreter /usr/libexec/qemu-binfmt/aarch64-binfmt-P flags: POCF
offset 0
magic 7f454c460201010000000000000000000200b700
mask ffffffffffffff00fffffffffffffffffeffffff

On an amd64 host:
$ debootstrap --arch=arm64 buster buster-chroot http://deb.debian.org/debian ...
$ chroot buster-chroot /bin/bash

See https://en.wikipedia.org/wiki/Binfmt_misc and
https://issues.guix.gnu.org/36117 for detail